### PR TITLE
Treat _bot accounts as bots

### DIFF
--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -60,7 +60,7 @@ export function isEmployee(login: string, employeesSet: Set<string>): boolean {
 
 export function isCommunityPR(authorLogin: string, employeesSet: Set<string>, authorAssociation?: string): boolean {
   // Exclude bots (including Dependabot - note: dependabot shows as "dependabot", not "dependabot[bot]")
-  const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin === 'dependabot';
+  const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
   
   // Exclude employees
   const isEmployeeUser = isEmployee(authorLogin, employeesSet);
@@ -78,7 +78,7 @@ export type AuthorType = 'employee' | 'maintainer' | 'community' | 'bot';
 
 export function getAuthorType(authorLogin: string, employeesSet: Set<string>, authorAssociation?: string): AuthorType {
   // Check for bots first (including Dependabot)
-  const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin === 'dependabot';
+  const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
   if (isBot) return 'bot';
   
   // Check for employees (org members)

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -544,7 +544,7 @@ export async function getAllPRReviewStats(
       if (!authorLogin) continue;
 
       // Determine author type
-      const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin === 'dependabot';
+      const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
       const isEmployee = employeesSet.has(authorLogin);
       const hasWriteAccess = ['COLLABORATOR', 'MEMBER', 'OWNER'].includes(authorAssociation);
 


### PR DESCRIPTION
## Summary
- treat logins ending with `_bot` as bots in author classification
- ensure bot-authored PR review stats categorize `_bot` accounts correctly

## Testing
- not run (not requested)
