### PR TITLE
Use explicit maintainer allowlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,6 @@ npm run test:watch   # Run Jest in watch mode
 - `next lint` does not exist in Next.js 16 — use `npm run lint` instead.
 - Path alias `@/` maps to the project root.
 - `app/page_old.tsx` is a legacy file with known lint warnings.
+- The active working fork is `enyst/oh-community-pr-dashboard`; upstream is `OpenHands/community-pr-dashboard`.
+- PR author badges now prefer repo maintainer status over employee status by deriving maintainers from the GitHub collaborators API in `buildRepoMaintainersSet` / `getRepoMaintainersREST`.
+- `__tests__/api/dashboard.test.ts` may need a larger Node heap in this environment; `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand __tests__/api/dashboard.test.ts` worked reliably.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ npm run test:watch   # Run Jest in watch mode
 - Path alias `@/` maps to the project root.
 - `app/page_old.tsx` is a legacy file with known lint warnings.
 - The active working fork is `enyst/oh-community-pr-dashboard`; upstream is `OpenHands/community-pr-dashboard`.
+- If a branch is first reviewed on the fork, the final handoff should close the fork PR and open an upstream PR from the same fork branch, with the fork PR left closed and linked to the upstream PR for traceability.
 - PR author badges use `config/maintainers.json` as the maintainer source of truth, with repo collaborators still derived from the GitHub collaborators API in `buildRepoAuthorRoleSets` / `getRepoCollaboratorsREST`.
 - Bot accounts should be filtered out of reviewer-facing metrics and requested-reviewer lists; author bot classification alone is not enough to remove bot reviewers from the dashboard.
 - Production HTML includes the deployed git SHA in a comment near the top of the document, which is useful for checking whether Vercel is serving the latest commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,6 @@ npm run test:watch   # Run Jest in watch mode
 - `next lint` does not exist in Next.js 16 — use `npm run lint` instead.
 - Path alias `@/` maps to the project root.
 - `app/page_old.tsx` is a legacy file with known lint warnings.
-- The active working fork is `enyst/oh-community-pr-dashboard`; upstream is `OpenHands/community-pr-dashboard`.
-- If a branch is first reviewed on the fork, the final handoff should close the fork PR and open an upstream PR from the same fork branch, with the fork PR left closed and linked to the upstream PR for traceability.
 - PR author badges use `config/maintainers.json` as the maintainer source of truth, with repo collaborators still derived from the GitHub collaborators API in `buildRepoAuthorRoleSets` / `getRepoCollaboratorsREST`.
 - Bot accounts should be filtered out of reviewer-facing metrics and requested-reviewer lists; author bot classification alone is not enough to remove bot reviewers from the dashboard.
 - Production HTML includes the deployed git SHA in a comment near the top of the document, which is useful for checking whether Vercel is serving the latest commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,5 +26,5 @@ npm run test:watch   # Run Jest in watch mode
 - Path alias `@/` maps to the project root.
 - `app/page_old.tsx` is a legacy file with known lint warnings.
 - The active working fork is `enyst/oh-community-pr-dashboard`; upstream is `OpenHands/community-pr-dashboard`.
-- PR author badges now distinguish repo maintainers (`maintain`/`admin`) from write-only collaborators by deriving repo author role sets from the GitHub collaborators API in `buildRepoAuthorRoleSets` / `getRepoAuthorRoleSetsREST`.
+- PR author badges use `config/maintainers.json` as the maintainer source of truth, with repo collaborators still derived from the GitHub collaborators API in `buildRepoAuthorRoleSets` / `getRepoCollaboratorsREST`.
 - `__tests__/api/dashboard.test.ts` may need a larger Node heap in this environment; `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand __tests__/api/dashboard.test.ts` worked reliably.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,5 +26,5 @@ npm run test:watch   # Run Jest in watch mode
 - Path alias `@/` maps to the project root.
 - `app/page_old.tsx` is a legacy file with known lint warnings.
 - The active working fork is `enyst/oh-community-pr-dashboard`; upstream is `OpenHands/community-pr-dashboard`.
-- PR author badges now prefer repo maintainer status over employee status by deriving maintainers from the GitHub collaborators API in `buildRepoMaintainersSet` / `getRepoMaintainersREST`.
+- PR author badges now distinguish repo maintainers (`maintain`/`admin`) from write-only collaborators by deriving repo author role sets from the GitHub collaborators API in `buildRepoAuthorRoleSets` / `getRepoAuthorRoleSetsREST`.
 - `__tests__/api/dashboard.test.ts` may need a larger Node heap in this environment; `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand __tests__/api/dashboard.test.ts` worked reliably.

--- a/__tests__/api/dashboard.test.ts
+++ b/__tests__/api/dashboard.test.ts
@@ -41,7 +41,6 @@ jest.mock('@/lib/cache', () => ({
 jest.mock('@/lib/employees', () => ({
   buildEmployeesSet: jest.fn(),
   buildRepoAuthorRoleSets: jest.fn(),
-  isCommunityPR: jest.fn(),
 }));
 
 // Keep the real RateLimitError class; replace network functions with mocks.

--- a/__tests__/api/dashboard.test.ts
+++ b/__tests__/api/dashboard.test.ts
@@ -40,7 +40,7 @@ jest.mock('@/lib/cache', () => ({
 
 jest.mock('@/lib/employees', () => ({
   buildEmployeesSet: jest.fn(),
-  buildRepoMaintainersSet: jest.fn(),
+  buildRepoAuthorRoleSets: jest.fn(),
   isCommunityPR: jest.fn(),
 }));
 
@@ -72,7 +72,7 @@ import {
   getRecentlyMergedPRsWithReviews,
   getAllPRReviewStats,
 } from '@/lib/github';
-import { buildEmployeesSet, buildRepoMaintainersSet } from '@/lib/employees';
+import { buildEmployeesSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 import {
   transformPR,
   computeDashboardData,
@@ -85,7 +85,7 @@ const mockGetOpenPRs        = getOpenPRsGraphQL               as jest.MockedFunc
 const mockGetMergedPRs      = getRecentlyMergedPRsWithReviews as jest.MockedFunction<typeof getRecentlyMergedPRsWithReviews>;
 const mockGetAllReviewStats = getAllPRReviewStats             as jest.MockedFunction<typeof getAllPRReviewStats>;
 const mockBuildEmployeesSet = buildEmployeesSet               as jest.MockedFunction<typeof buildEmployeesSet>;
-const mockBuildRepoMaintainersSet = buildRepoMaintainersSet   as jest.MockedFunction<typeof buildRepoMaintainersSet>;
+const mockBuildRepoAuthorRoleSets = buildRepoAuthorRoleSets   as jest.MockedFunction<typeof buildRepoAuthorRoleSets>;
 const mockTransformPR             = transformPR               as jest.MockedFunction<typeof transformPR>;
 const mockComputeDashboardData    = computeDashboardData           as jest.MockedFunction<typeof computeDashboardData>;
 const mockComputeCommunityStats   = computeCommunityReviewerStats  as jest.MockedFunction<typeof computeCommunityReviewerStats>;
@@ -136,7 +136,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   mockBuildEmployeesSet.mockResolvedValue(new Set<string>());
-  mockBuildRepoMaintainersSet.mockResolvedValue(new Set<string>());
+  mockBuildRepoAuthorRoleSets.mockResolvedValue({ maintainers: new Set<string>(), collaborators: new Set<string>() });
   mockGetOpenPRs.mockResolvedValue([]);
   mockGetMergedPRs.mockResolvedValue(EMPTY_REVIEW_STATS);
   mockGetAllReviewStats.mockResolvedValue(EMPTY_ALL_REVIEW_STATS);

--- a/__tests__/api/dashboard.test.ts
+++ b/__tests__/api/dashboard.test.ts
@@ -40,6 +40,7 @@ jest.mock('@/lib/cache', () => ({
 
 jest.mock('@/lib/employees', () => ({
   buildEmployeesSet: jest.fn(),
+  buildRepoMaintainersSet: jest.fn(),
   isCommunityPR: jest.fn(),
 }));
 
@@ -71,7 +72,7 @@ import {
   getRecentlyMergedPRsWithReviews,
   getAllPRReviewStats,
 } from '@/lib/github';
-import { buildEmployeesSet } from '@/lib/employees';
+import { buildEmployeesSet, buildRepoMaintainersSet } from '@/lib/employees';
 import {
   transformPR,
   computeDashboardData,
@@ -80,11 +81,12 @@ import {
   computeBotReviewerStats,
 } from '@/lib/compute';
 
-const mockGetOpenPRs        = getOpenPRsGraphQL              as jest.MockedFunction<typeof getOpenPRsGraphQL>;
+const mockGetOpenPRs        = getOpenPRsGraphQL               as jest.MockedFunction<typeof getOpenPRsGraphQL>;
 const mockGetMergedPRs      = getRecentlyMergedPRsWithReviews as jest.MockedFunction<typeof getRecentlyMergedPRsWithReviews>;
 const mockGetAllReviewStats = getAllPRReviewStats             as jest.MockedFunction<typeof getAllPRReviewStats>;
-const mockBuildEmployeesSet = buildEmployeesSet              as jest.MockedFunction<typeof buildEmployeesSet>;
-const mockTransformPR             = transformPR                    as jest.MockedFunction<typeof transformPR>;
+const mockBuildEmployeesSet = buildEmployeesSet               as jest.MockedFunction<typeof buildEmployeesSet>;
+const mockBuildRepoMaintainersSet = buildRepoMaintainersSet   as jest.MockedFunction<typeof buildRepoMaintainersSet>;
+const mockTransformPR             = transformPR               as jest.MockedFunction<typeof transformPR>;
 const mockComputeDashboardData    = computeDashboardData           as jest.MockedFunction<typeof computeDashboardData>;
 const mockComputeCommunityStats   = computeCommunityReviewerStats  as jest.MockedFunction<typeof computeCommunityReviewerStats>;
 const mockComputeOrgMemberStats   = computeOrgMemberReviewerStats  as jest.MockedFunction<typeof computeOrgMemberReviewerStats>;
@@ -134,6 +136,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   mockBuildEmployeesSet.mockResolvedValue(new Set<string>());
+  mockBuildRepoMaintainersSet.mockResolvedValue(new Set<string>());
   mockGetOpenPRs.mockResolvedValue([]);
   mockGetMergedPRs.mockResolvedValue(EMPTY_REVIEW_STATS);
   mockGetAllReviewStats.mockResolvedValue(EMPTY_ALL_REVIEW_STATS);

--- a/__tests__/lib/authorRoles.test.ts
+++ b/__tests__/lib/authorRoles.test.ts
@@ -22,38 +22,57 @@ jest.mock('@/lib/github', () => ({
 }));
 
 import { readFileSync } from 'fs';
-import { getRepoCollaboratorsREST } from '@/lib/github';
-import { buildMaintainersSet, buildRepoAuthorRoleSets } from '@/lib/employees';
+import { getOrgMembersGraphQL, getRepoCollaboratorsREST } from '@/lib/github';
+import { buildEmployeesSet, buildMaintainersSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 
 const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+const mockGetOrgMembersGraphQL = getOrgMembersGraphQL as jest.MockedFunction<typeof getOrgMembersGraphQL>;
 const mockGetRepoCollaboratorsREST = getRepoCollaboratorsREST as jest.MockedFunction<typeof getRepoCollaboratorsREST>;
 
 beforeEach(() => {
   jest.clearAllMocks();
+
   mockReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
-    if (String(path).endsWith('maintainers.json')) {
+    const pathString = String(path);
+
+    if (pathString.endsWith('employees.json')) {
       return JSON.stringify({
-        allowlist: ['enyst', 'rbren'],
-        denylist: [],
+        allowlist: ['added-employee'],
+        denylist: ['removed-employee'],
       }) as ReturnType<typeof readFileSync>;
     }
 
-    throw new Error(`Unexpected file read: ${String(path)}`);
+    if (pathString.endsWith('maintainers.json')) {
+      return JSON.stringify({
+        allowlist: ['enyst', 'rbren'],
+        denylist: ['rbren'],
+      }) as ReturnType<typeof readFileSync>;
+    }
+
+    throw new Error(`Unexpected file read: ${pathString}`);
   });
-  mockGetRepoCollaboratorsREST.mockResolvedValue(['enyst', 'write-user']);
+
+  mockGetOrgMembersGraphQL.mockResolvedValue(['org-employee', 'removed-employee']);
+  mockGetRepoCollaboratorsREST.mockResolvedValue(['enyst', 'rbren', 'write-user']);
 });
 
-describe('maintainer role sources', () => {
-  it('builds the maintainer set from config/maintainers.json', async () => {
+describe('override-backed author role builders', () => {
+  it('applies employee allowlist and denylist overrides', async () => {
+    const employees = await buildEmployeesSet();
+
+    expect(employees).toEqual(new Set(['org-employee', 'added-employee']));
+  });
+
+  it('applies maintainer allowlist and denylist overrides', async () => {
     const maintainers = await buildMaintainersSet();
 
-    expect(maintainers).toEqual(new Set(['enyst', 'rbren']));
+    expect(maintainers).toEqual(new Set(['enyst']));
   });
 
   it('keeps explicit maintainers out of the collaborator bucket', async () => {
     const roleSets = await buildRepoAuthorRoleSets('OpenHands', 'OpenHands');
 
-    expect(roleSets.maintainers).toEqual(new Set(['enyst', 'rbren']));
-    expect(roleSets.collaborators).toEqual(new Set(['write-user']));
+    expect(roleSets.maintainers).toEqual(new Set(['enyst']));
+    expect(roleSets.collaborators).toEqual(new Set(['rbren', 'write-user']));
   });
 });

--- a/__tests__/lib/authorRoles.test.ts
+++ b/__tests__/lib/authorRoles.test.ts
@@ -16,6 +16,14 @@ jest.mock('@/lib/config', () => ({
 }));
 
 jest.mock('@/lib/github', () => ({
+  RateLimitError: class RateLimitError extends Error {
+    constructor(resetAt: string) {
+      super('GitHub API rate limit exceeded');
+      this.name = 'RateLimitError';
+      this.resetAt = resetAt;
+    }
+    resetAt: string;
+  },
   getOrgMembersGraphQL: jest.fn(),
   getOrgMembersREST: jest.fn(),
   getRepoCollaboratorsREST: jest.fn(),
@@ -75,4 +83,14 @@ describe('override-backed author role builders', () => {
     expect(roleSets.maintainers).toEqual(new Set(['enyst']));
     expect(roleSets.collaborators).toEqual(new Set(['rbren', 'write-user']));
   });
+
+  it('falls back to explicit maintainers when collaborator lookup fails', async () => {
+    mockGetRepoCollaboratorsREST.mockRejectedValueOnce(new Error('collaborators unavailable'));
+
+    const roleSets = await buildRepoAuthorRoleSets('OpenHands', 'OpenHands');
+
+    expect(roleSets.maintainers).toEqual(new Set(['enyst']));
+    expect(roleSets.collaborators).toEqual(new Set());
+  });
+
 });

--- a/__tests__/lib/authorRoles.test.ts
+++ b/__tests__/lib/authorRoles.test.ts
@@ -93,4 +93,33 @@ describe('override-backed author role builders', () => {
     expect(roleSets.collaborators).toEqual(new Set());
   });
 
+  it('normalizes malformed override file shapes', async () => {
+    mockReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
+      const pathString = String(path);
+
+      if (pathString.endsWith('employees.json')) {
+        return JSON.stringify({
+          allowlist: 'not-an-array',
+          denylist: [null, 'removed-employee', 123],
+        }) as ReturnType<typeof readFileSync>;
+      }
+
+      if (pathString.endsWith('maintainers.json')) {
+        return JSON.stringify({
+          allowlist: ['enyst', false],
+          denylist: 'not-an-array',
+        }) as ReturnType<typeof readFileSync>;
+      }
+
+      throw new Error(`Unexpected file read: ${pathString}`);
+    });
+
+    const employees = await buildEmployeesSet();
+    const maintainers = await buildMaintainersSet();
+
+    expect(employees).toEqual(new Set(['org-employee']));
+    expect(maintainers).toEqual(new Set(['enyst']));
+  });
+
+
 });

--- a/__tests__/lib/authorRoles.test.ts
+++ b/__tests__/lib/authorRoles.test.ts
@@ -1,0 +1,59 @@
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+}));
+
+jest.mock('@/lib/cache', () => ({
+  cache: {
+    withCache: jest.fn((_key: string, _ttl: number, fn: () => Promise<unknown>) => fn()),
+  },
+}));
+
+jest.mock('@/lib/config', () => ({
+  config: {
+    cache: { ttlSeconds: 60 },
+    orgs: ['test-org'],
+  },
+}));
+
+jest.mock('@/lib/github', () => ({
+  getOrgMembersGraphQL: jest.fn(),
+  getOrgMembersREST: jest.fn(),
+  getRepoCollaboratorsREST: jest.fn(),
+}));
+
+import { readFileSync } from 'fs';
+import { getRepoCollaboratorsREST } from '@/lib/github';
+import { buildMaintainersSet, buildRepoAuthorRoleSets } from '@/lib/employees';
+
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+const mockGetRepoCollaboratorsREST = getRepoCollaboratorsREST as jest.MockedFunction<typeof getRepoCollaboratorsREST>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
+    if (String(path).endsWith('maintainers.json')) {
+      return JSON.stringify({
+        allowlist: ['enyst', 'rbren'],
+        denylist: [],
+      }) as ReturnType<typeof readFileSync>;
+    }
+
+    throw new Error(`Unexpected file read: ${String(path)}`);
+  });
+  mockGetRepoCollaboratorsREST.mockResolvedValue(['enyst', 'write-user']);
+});
+
+describe('maintainer role sources', () => {
+  it('builds the maintainer set from config/maintainers.json', async () => {
+    const maintainers = await buildMaintainersSet();
+
+    expect(maintainers).toEqual(new Set(['enyst', 'rbren']));
+  });
+
+  it('keeps explicit maintainers out of the collaborator bucket', async () => {
+    const roleSets = await buildRepoAuthorRoleSets('OpenHands', 'OpenHands');
+
+    expect(roleSets.maintainers).toEqual(new Set(['enyst', 'rbren']));
+    expect(roleSets.collaborators).toEqual(new Set(['write-user']));
+  });
+});

--- a/__tests__/lib/compute.test.ts
+++ b/__tests__/lib/compute.test.ts
@@ -5,12 +5,6 @@ import { ReviewStatsData } from '@/lib/github';
 // Mock the employees module
 jest.mock('@/lib/employees', () => ({
   isEmployee: (login: string, employeesSet: Set<string>) => employeesSet.has(login),
-  isCommunityPR: (authorLogin: string, employeesSet: Set<string>, authorAssociation?: string) => {
-    const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin === 'dependabot';
-    const isEmployeeUser = employeesSet.has(authorLogin);
-    const hasWriteAccess = authorAssociation === 'COLLABORATOR' || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
-    return !isBot && !isEmployeeUser && !hasWriteAccess;
-  },
   getAuthorType: (authorLogin: string, employeesSet: Set<string>, authorAssociation?: string, repoAuthorRoleSets = { maintainers: new Set<string>(), collaborators: new Set<string>() }) => {
     const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin === 'dependabot';
     if (isBot) return 'bot';

--- a/__tests__/lib/compute.test.ts
+++ b/__tests__/lib/compute.test.ts
@@ -7,7 +7,8 @@ jest.mock('@/lib/employees', () => ({
   isEmployee: (login: string, employeesSet: Set<string>) => employeesSet.has(login),
   isOrgMemberAssociation: (authorAssociation?: string) => authorAssociation === 'MEMBER' || authorAssociation === 'OWNER',
   getAuthorType: (authorLogin: string, employeesSet: Set<string>, authorAssociation?: string, repoAuthorRoleSets = { maintainers: new Set<string>(), collaborators: new Set<string>() }) => {
-    const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
+    const normalizedLogin = authorLogin.toLowerCase();
+    const isBot = normalizedLogin.includes('[bot]') || normalizedLogin.endsWith('-bot') || normalizedLogin.endsWith('_bot') || normalizedLogin === 'dependabot';
     if (isBot) return 'bot';
     if (repoAuthorRoleSets.maintainers.has(authorLogin)) return 'maintainer';
     if (employeesSet.has(authorLogin) || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER') return 'employee';

--- a/__tests__/lib/compute.test.ts
+++ b/__tests__/lib/compute.test.ts
@@ -11,12 +11,12 @@ jest.mock('@/lib/employees', () => ({
     const hasWriteAccess = authorAssociation === 'COLLABORATOR' || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
     return !isBot && !isEmployeeUser && !hasWriteAccess;
   },
-  getAuthorType: (authorLogin: string, employeesSet: Set<string>, authorAssociation?: string) => {
+  getAuthorType: (authorLogin: string, employeesSet: Set<string>, authorAssociation?: string, repoAuthorRoleSets = { maintainers: new Set<string>(), collaborators: new Set<string>() }) => {
     const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin === 'dependabot';
     if (isBot) return 'bot';
-    if (employeesSet.has(authorLogin)) return 'employee';
-    const hasWriteAccess = authorAssociation === 'COLLABORATOR' || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
-    if (hasWriteAccess) return 'maintainer';
+    if (repoAuthorRoleSets.maintainers.has(authorLogin)) return 'maintainer';
+    if (employeesSet.has(authorLogin) || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER') return 'employee';
+    if (repoAuthorRoleSets.collaborators.has(authorLogin) || authorAssociation === 'COLLABORATOR') return 'collaborator';
     return 'community';
   },
 }));

--- a/__tests__/lib/employees.test.ts
+++ b/__tests__/lib/employees.test.ts
@@ -3,7 +3,7 @@ import { getAuthorType } from '@/lib/employees';
 describe('getAuthorType', () => {
   const employeesSet = new Set(['employee-maintainer', 'employee-only']);
   const repoAuthorRoleSets = {
-    maintainers: new Set(['employee-maintainer', 'external-maintainer']),
+    maintainers: new Set(['employee-maintainer', 'non-org-maintainer']),
     collaborators: new Set(['write-collaborator']),
   };
 
@@ -15,8 +15,8 @@ describe('getAuthorType', () => {
     expect(getAuthorType('employee-only', employeesSet, 'MEMBER', repoAuthorRoleSets)).toBe('employee');
   });
 
-  it('classifies external maintainers from repo permissions', () => {
-    expect(getAuthorType('external-maintainer', employeesSet, 'COLLABORATOR', repoAuthorRoleSets)).toBe('maintainer');
+  it('classifies non-org maintainers from repo permissions', () => {
+    expect(getAuthorType('non-org-maintainer', employeesSet, 'COLLABORATOR', repoAuthorRoleSets)).toBe('maintainer');
   });
 
   it('classifies write-only collaborators separately from maintainers', () => {

--- a/__tests__/lib/employees.test.ts
+++ b/__tests__/lib/employees.test.ts
@@ -2,21 +2,32 @@ import { getAuthorType } from '@/lib/employees';
 
 describe('getAuthorType', () => {
   const employeesSet = new Set(['employee-maintainer', 'employee-only']);
-  const maintainersSet = new Set(['employee-maintainer', 'external-maintainer']);
+  const repoAuthorRoleSets = {
+    maintainers: new Set(['employee-maintainer', 'external-maintainer']),
+    collaborators: new Set(['write-collaborator']),
+  };
 
   it('prefers maintainer over employee when a login is both', () => {
-    expect(getAuthorType('employee-maintainer', employeesSet, 'MEMBER', maintainersSet)).toBe('maintainer');
+    expect(getAuthorType('employee-maintainer', employeesSet, 'MEMBER', repoAuthorRoleSets)).toBe('maintainer');
   });
 
   it('keeps employees as employees when they are not repo maintainers', () => {
-    expect(getAuthorType('employee-only', employeesSet, 'MEMBER', maintainersSet)).toBe('employee');
+    expect(getAuthorType('employee-only', employeesSet, 'MEMBER', repoAuthorRoleSets)).toBe('employee');
   });
 
-  it('classifies external collaborators as maintainers', () => {
-    expect(getAuthorType('external-maintainer', employeesSet, 'COLLABORATOR', maintainersSet)).toBe('maintainer');
+  it('classifies external maintainers from repo permissions', () => {
+    expect(getAuthorType('external-maintainer', employeesSet, 'COLLABORATOR', repoAuthorRoleSets)).toBe('maintainer');
+  });
+
+  it('classifies write-only collaborators separately from maintainers', () => {
+    expect(getAuthorType('write-collaborator', employeesSet, 'COLLABORATOR', repoAuthorRoleSets)).toBe('collaborator');
+  });
+
+  it('uses MEMBER association as a fallback employee signal', () => {
+    expect(getAuthorType('member-only', new Set(), 'MEMBER', repoAuthorRoleSets)).toBe('employee');
   });
 
   it('classifies outside contributors as community', () => {
-    expect(getAuthorType('community-user', employeesSet, 'CONTRIBUTOR', maintainersSet)).toBe('community');
+    expect(getAuthorType('community-user', employeesSet, 'CONTRIBUTOR', repoAuthorRoleSets)).toBe('community');
   });
 });

--- a/__tests__/lib/employees.test.ts
+++ b/__tests__/lib/employees.test.ts
@@ -23,6 +23,10 @@ describe('getAuthorType', () => {
     expect(getAuthorType('write-collaborator', employeesSet, 'COLLABORATOR', repoAuthorRoleSets)).toBe('collaborator');
   });
 
+  it('classifies bot accounts as bot', () => {
+    expect(getAuthorType('dependabot[bot]', employeesSet, 'NONE', repoAuthorRoleSets)).toBe('bot');
+  });
+
   it('uses MEMBER association as a fallback employee signal', () => {
     expect(getAuthorType('member-only', new Set(), 'MEMBER', repoAuthorRoleSets)).toBe('employee');
   });

--- a/__tests__/lib/employees.test.ts
+++ b/__tests__/lib/employees.test.ts
@@ -1,0 +1,22 @@
+import { getAuthorType } from '@/lib/employees';
+
+describe('getAuthorType', () => {
+  const employeesSet = new Set(['employee-maintainer', 'employee-only']);
+  const maintainersSet = new Set(['employee-maintainer', 'external-maintainer']);
+
+  it('prefers maintainer over employee when a login is both', () => {
+    expect(getAuthorType('employee-maintainer', employeesSet, 'MEMBER', maintainersSet)).toBe('maintainer');
+  });
+
+  it('keeps employees as employees when they are not repo maintainers', () => {
+    expect(getAuthorType('employee-only', employeesSet, 'MEMBER', maintainersSet)).toBe('employee');
+  });
+
+  it('classifies external collaborators as maintainers', () => {
+    expect(getAuthorType('external-maintainer', employeesSet, 'COLLABORATOR', maintainersSet)).toBe('maintainer');
+  });
+
+  it('classifies outside contributors as community', () => {
+    expect(getAuthorType('community-user', employeesSet, 'CONTRIBUTOR', maintainersSet)).toBe('community');
+  });
+});

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { config } from '@/lib/config';
 import { cache } from '@/lib/cache';
-import { buildEmployeesSet, buildRepoMaintainersSet } from '@/lib/employees';
+import { buildEmployeesSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 import { RateLimitError, getOpenPRsGraphQL, getRecentlyMergedPRsWithReviews, getAllPRReviewStats, ReviewStatsData, CommunityPRReviewData, OrgMemberPRReviewData, BotPRReviewData } from '@/lib/github';
 import { transformPR, computeDashboardData, computeCommunityReviewerStats, computeOrgMemberReviewerStats, computeBotReviewerStats } from '@/lib/compute';
 import { PR } from '@/lib/types';
@@ -77,12 +77,12 @@ export async function GET(request: NextRequest) {
               getOpenPRsGraphQL(owner, repo),
               getRecentlyMergedPRsWithReviews(owner, repo, 30),
               getAllPRReviewStats(owner, repo, 30, employeesSet),
-              buildRepoMaintainersSet(owner, repo),
+              buildRepoAuthorRoleSets(owner, repo),
             ])
-              .then(([rawPrs, reviewStatsData, allReviewStats, maintainersSet]): RepoData => ({
+              .then(([rawPrs, reviewStatsData, allReviewStats, repoAuthorRoleSets]): RepoData => ({
                 prs: rawPrs.map(rawPr => {
                   rawPr.repository = { owner: { login: owner }, name: repo };
-                  return transformPR(rawPr, employeesSet, maintainersSet);
+                  return transformPR(rawPr, employeesSet, repoAuthorRoleSets);
                 }),
                 reviewStatsData,
                 communityReviews: allReviewStats.communityReviews,

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { config } from '@/lib/config';
 import { cache } from '@/lib/cache';
-import { buildEmployeesSet } from '@/lib/employees';
+import { buildEmployeesSet, buildRepoMaintainersSet } from '@/lib/employees';
 import { RateLimitError, getOpenPRsGraphQL, getRecentlyMergedPRsWithReviews, getAllPRReviewStats, ReviewStatsData, CommunityPRReviewData, OrgMemberPRReviewData, BotPRReviewData } from '@/lib/github';
 import { transformPR, computeDashboardData, computeCommunityReviewerStats, computeOrgMemberReviewerStats, computeBotReviewerStats } from '@/lib/compute';
 import { PR } from '@/lib/types';
@@ -77,11 +77,12 @@ export async function GET(request: NextRequest) {
               getOpenPRsGraphQL(owner, repo),
               getRecentlyMergedPRsWithReviews(owner, repo, 30),
               getAllPRReviewStats(owner, repo, 30, employeesSet),
+              buildRepoMaintainersSet(owner, repo),
             ])
-              .then(([rawPrs, reviewStatsData, allReviewStats]): RepoData => ({
+              .then(([rawPrs, reviewStatsData, allReviewStats, maintainersSet]): RepoData => ({
                 prs: rawPrs.map(rawPr => {
                   rawPr.repository = { owner: { login: owner }, name: repo };
-                  return transformPR(rawPr, employeesSet);
+                  return transformPR(rawPr, employeesSet, maintainersSet);
                 }),
                 reviewStatsData,
                 communityReviews: allReviewStats.communityReviews,

--- a/app/api/review-stats/route.ts
+++ b/app/api/review-stats/route.ts
@@ -3,10 +3,11 @@ import { NextRequest, NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 import { config, validateConfig } from '@/lib/config';
 import { cache } from '@/lib/cache';
-import { buildEmployeesSet } from '@/lib/employees';
+import { buildEmployeesSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 import { getOpenPRsGraphQL } from '@/lib/github';
 import { transformPR, computeReviewStats } from '@/lib/compute';
 import { PR } from '@/lib/types';
+import { DEFAULT_REPOS } from '@/lib/defaults';
 
 export async function GET(_request: NextRequest) {
   try {
@@ -21,22 +22,21 @@ export async function GET(_request: NextRequest) {
       // Get all PRs from configured repositories
       const allPrs: PR[] = [];
       
-      // For MVP, use hardcoded repos (same as dashboard)
-      const reposToFetch = config.repos.include.length > 0 ? config.repos.include : [
-        'All-Hands-AI/OpenHands',
-        'All-Hands-AI/agent-sdk',
-      ];
+      const reposToFetch = config.repos.include.length > 0 ? config.repos.include : DEFAULT_REPOS;
       
       for (const repoPath of reposToFetch) {
         const [owner, repo] = repoPath.split('/');
         if (!owner || !repo) continue;
         
         try {
-          const rawPrs = await getOpenPRsGraphQL(owner, repo);
+          const [rawPrs, repoAuthorRoleSets] = await Promise.all([
+            getOpenPRsGraphQL(owner, repo),
+            buildRepoAuthorRoleSets(owner, repo),
+          ]);
           const transformedPrs = rawPrs.map(rawPr => {
             // Add repo info to raw PR for transformation
             rawPr.repository = { owner: { login: owner }, name: repo };
-            return transformPR(rawPr, employeesSet);
+            return transformPR(rawPr, employeesSet, repoAuthorRoleSets);
           });
           
           allPrs.push(...transformedPrs);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -590,6 +590,7 @@ export default function Dashboard() {
                     { value: 'community', label: 'Community' },
                     { value: 'employee', label: 'Employee' },
                     { value: 'maintainer', label: 'Maintainer' },
+                    { value: 'collaborator', label: 'Collaborator' },
                     { value: 'bot', label: 'Bot' }
                   ]}
                   value={filters.authorType || 'all'}

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -1,6 +1,6 @@
 interface BadgeProps {
   children: React.ReactNode;
-  variant?: 'community' | 'employee' | 'maintainer' | 'bot' | 'overdue' | 'needs-response' | 'default';
+  variant?: 'community' | 'employee' | 'maintainer' | 'collaborator' | 'bot' | 'overdue' | 'needs-response' | 'default';
   className?: string;
 }
 
@@ -9,6 +9,7 @@ export default function Badge({ children, variant = 'default', className = '' }:
     community: 'bg-blue-100 text-blue-800',
     employee: 'bg-green-100 text-green-800',
     maintainer: 'bg-purple-100 text-purple-800',
+    collaborator: 'bg-amber-100 text-amber-800',
     bot: 'bg-gray-100 text-gray-600',
     overdue: 'bg-red-100 text-red-800',
     'needs-response': 'bg-yellow-100 text-yellow-800',

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,0 +1,15 @@
+{
+  "allowlist": [
+    "malhotra5",
+    "rbren",
+    "xingyaoww",
+    "neubig",
+    "csmith49",
+    "hieptl",
+    "enyst",
+    "mamoodi",
+    "li-boxuan",
+    "tobitege"
+  ],
+  "denylist": []
+}

--- a/lib/compute.ts
+++ b/lib/compute.ts
@@ -1,6 +1,6 @@
 import { PR, Review, KPIs, ReviewStatsResponse, Reviewer, CommunityReviewerStats, OrgMemberReviewerStats, BotReviewerStats, RepoAuthorRoleSets } from './types';
 import { config } from './config';
-import { isEmployee, getAuthorType } from './employees';
+import { isEmployee, getAuthorType, isOrgMemberAssociation } from './employees';
 import { ReviewStatsData, CommunityPRReviewData, OrgMemberPRReviewData, BotPRReviewData } from './github';
 
 // Minimum number of data points required for a meaningful median
@@ -110,7 +110,7 @@ export function transformPR(
     authorLogin,
     authorAssociation,
     authorType: getAuthorType(authorLogin, employeesSet, authorAssociation, repoAuthorRoleSets),
-    isEmployeeAuthor: isEmployee(authorLogin, employeesSet) || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER',
+    isEmployeeAuthor: isEmployee(authorLogin, employeesSet) || isOrgMemberAssociation(authorAssociation),
     isDraft: rawPR.isDraft,
     createdAt: rawPR.createdAt,
     updatedAt: rawPR.updatedAt,

--- a/lib/compute.ts
+++ b/lib/compute.ts
@@ -68,7 +68,7 @@ export function computeFlags(
   };
 }
 
-export function transformPR(rawPR: any, employeesSet: Set<string>): PR {
+export function transformPR(rawPR: any, employeesSet: Set<string>, maintainersSet: Set<string> = new Set()): PR {
   const { firstHumanResponseAt, firstReviewAt } = computeFirsts(rawPR, employeesSet);
   const flags = computeFlags(rawPR, firstHumanResponseAt, firstReviewAt);
   
@@ -105,7 +105,7 @@ export function transformPR(rawPR: any, employeesSet: Set<string>): PR {
     url: rawPR.url,
     authorLogin,
     authorAssociation,
-    authorType: getAuthorType(authorLogin, employeesSet, authorAssociation),
+    authorType: getAuthorType(authorLogin, employeesSet, authorAssociation, maintainersSet),
     isEmployeeAuthor: isEmployee(authorLogin, employeesSet),
     isDraft: rawPR.isDraft,
     createdAt: rawPR.createdAt,

--- a/lib/compute.ts
+++ b/lib/compute.ts
@@ -1,6 +1,6 @@
 import { PR, Review, KPIs, ReviewStatsResponse, Reviewer, CommunityReviewerStats, OrgMemberReviewerStats, BotReviewerStats, RepoAuthorRoleSets } from './types';
 import { config } from './config';
-import { isEmployee, isCommunityPR, getAuthorType } from './employees';
+import { isEmployee, getAuthorType } from './employees';
 import { ReviewStatsData, CommunityPRReviewData, OrgMemberPRReviewData, BotPRReviewData } from './github';
 
 // Minimum number of data points required for a meaningful median
@@ -125,7 +125,7 @@ export function transformPR(
 }
 
 export function computeKpis(allPrs: PR[], employeesSet: Set<string>): KPIs {
-  const communityPrs = allPrs.filter(pr => isCommunityPR(pr.authorLogin, employeesSet, pr.authorAssociation));
+  const communityPrs = allPrs.filter(pr => pr.authorType === 'community');
   const nonDraftPrs = allPrs.filter(pr => !pr.isDraft);
   
   // Calculate medians - use readyForReviewAt as start time (handles draft PRs correctly)
@@ -296,7 +296,7 @@ export function computeDashboardData(
   employeesSet: Set<string>,
   reviewStatsData: ReviewStatsData = { completedReviews: [], reviewRequests: [] }
 ): import('./types').DashboardData {
-  const communityPrs = allPrs.filter(pr => isCommunityPR(pr.authorLogin, employeesSet, pr.authorAssociation));
+  const communityPrs = allPrs.filter(pr => pr.authorType === 'community');
   const nonDraftPrs = allPrs.filter(pr => !pr.isDraft);
   
   // Calculate medians - use readyForReviewAt as start time (handles draft PRs correctly)

--- a/lib/compute.ts
+++ b/lib/compute.ts
@@ -1,4 +1,4 @@
-import { PR, Review, KPIs, ReviewStatsResponse, Reviewer, CommunityReviewerStats, OrgMemberReviewerStats, BotReviewerStats } from './types';
+import { PR, Review, KPIs, ReviewStatsResponse, Reviewer, CommunityReviewerStats, OrgMemberReviewerStats, BotReviewerStats, RepoAuthorRoleSets } from './types';
 import { config } from './config';
 import { isEmployee, isCommunityPR, getAuthorType } from './employees';
 import { ReviewStatsData, CommunityPRReviewData, OrgMemberPRReviewData, BotPRReviewData } from './github';
@@ -68,7 +68,11 @@ export function computeFlags(
   };
 }
 
-export function transformPR(rawPR: any, employeesSet: Set<string>, maintainersSet: Set<string> = new Set()): PR {
+export function transformPR(
+  rawPR: any,
+  employeesSet: Set<string>,
+  repoAuthorRoleSets: RepoAuthorRoleSets = { maintainers: new Set(), collaborators: new Set() }
+): PR {
   const { firstHumanResponseAt, firstReviewAt } = computeFirsts(rawPR, employeesSet);
   const flags = computeFlags(rawPR, firstHumanResponseAt, firstReviewAt);
   
@@ -105,8 +109,8 @@ export function transformPR(rawPR: any, employeesSet: Set<string>, maintainersSe
     url: rawPR.url,
     authorLogin,
     authorAssociation,
-    authorType: getAuthorType(authorLogin, employeesSet, authorAssociation, maintainersSet),
-    isEmployeeAuthor: isEmployee(authorLogin, employeesSet),
+    authorType: getAuthorType(authorLogin, employeesSet, authorAssociation, repoAuthorRoleSets),
+    isEmployeeAuthor: isEmployee(authorLogin, employeesSet) || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER',
     isDraft: rawPR.isDraft,
     createdAt: rawPR.createdAt,
     updatedAt: rawPR.updatedAt,

--- a/lib/compute.ts
+++ b/lib/compute.ts
@@ -124,7 +124,7 @@ export function transformPR(
   };
 }
 
-export function computeKpis(allPrs: PR[], _employeesSet: Set<string>): KPIs {
+export function computeKpis(allPrs: PR[]): KPIs {
   const communityPrs = allPrs.filter(pr => pr.authorType === 'community');
   const nonDraftPrs = allPrs.filter(pr => !pr.isDraft);
   

--- a/lib/compute.ts
+++ b/lib/compute.ts
@@ -124,7 +124,7 @@ export function transformPR(
   };
 }
 
-export function computeKpis(allPrs: PR[], employeesSet: Set<string>): KPIs {
+export function computeKpis(allPrs: PR[], _employeesSet: Set<string>): KPIs {
   const communityPrs = allPrs.filter(pr => pr.authorType === 'community');
   const nonDraftPrs = allPrs.filter(pr => !pr.isDraft);
   

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { config } from './config';
 import { cache } from './cache';
-import { getOrgMembersGraphQL, getOrgMembersREST, getRepoCollaboratorsREST } from './github';
+import { RateLimitError, getOrgMembersGraphQL, getOrgMembersREST, getRepoCollaboratorsREST } from './github';
 import { EmployeeOverrides, LoginOverrides, MaintainerOverrides, RepoAuthorRoleSets } from './types';
 
 function loadOverrides(fileName: string): LoginOverrides {
@@ -90,6 +90,7 @@ export async function buildRepoAuthorRoleSets(owner: string, repo: string): Prom
         collaborators: new Set(collaborators.filter(login => !maintainersSet.has(login))),
       };
     } catch (error) {
+      if (error instanceof RateLimitError) throw error;
       console.error(`Failed to fetch repo author roles for ${owner}/${repo}:`, error);
       return {
         maintainers: new Set<string>(),

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -2,18 +2,25 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { config } from './config';
 import { cache } from './cache';
-import { getOrgMembersGraphQL, getOrgMembersREST, getRepoAuthorRoleSetsREST } from './github';
-import { EmployeeOverrides, RepoAuthorRoleSets } from './types';
+import { getOrgMembersGraphQL, getOrgMembersREST, getRepoCollaboratorsREST } from './github';
+import { EmployeeOverrides, LoginOverrides, MaintainerOverrides, RepoAuthorRoleSets } from './types';
 
-function loadEmployeeOverrides(): EmployeeOverrides {
+function loadOverrides(fileName: string): LoginOverrides {
   try {
-    const filePath = join(process.cwd(), 'config', 'employees.json');
+    const filePath = join(process.cwd(), 'config', fileName);
     const fileContent = readFileSync(filePath, 'utf-8');
     return JSON.parse(fileContent);
   } catch {
-    // If file doesn't exist or is invalid, return empty overrides
     return { allowlist: [], denylist: [] };
   }
+}
+
+function loadEmployeeOverrides(): EmployeeOverrides {
+  return loadOverrides('employees.json');
+}
+
+function loadMaintainerOverrides(): MaintainerOverrides {
+  return loadOverrides('maintainers.json');
 }
 
 export async function buildEmployeesSet(): Promise<Set<string>> {
@@ -54,15 +61,33 @@ export async function buildEmployeesSet(): Promise<Set<string>> {
   });
 }
 
+export async function buildMaintainersSet(): Promise<Set<string>> {
+  const cacheKey = 'maintainers';
+
+  return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
+    const maintainers = new Set<string>();
+    const overrides = loadMaintainerOverrides();
+
+    overrides.allowlist.forEach(login => maintainers.add(login));
+    overrides.denylist.forEach(login => maintainers.delete(login));
+
+    return maintainers;
+  });
+}
+
 export async function buildRepoAuthorRoleSets(owner: string, repo: string): Promise<RepoAuthorRoleSets> {
   const cacheKey = `repo-author-roles:${owner}/${repo}`;
 
   return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
     try {
-      const roleSets = await getRepoAuthorRoleSetsREST(owner, repo);
+      const [maintainersSet, collaborators] = await Promise.all([
+        buildMaintainersSet(),
+        getRepoCollaboratorsREST(owner, repo),
+      ]);
+
       return {
-        maintainers: new Set(roleSets.maintainers),
-        collaborators: new Set(roleSets.collaborators),
+        maintainers: new Set(maintainersSet),
+        collaborators: new Set(collaborators.filter(login => !maintainersSet.has(login))),
       };
     } catch (error) {
       console.error(`Failed to fetch repo author roles for ${owner}/${repo}:`, error);

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -105,8 +105,7 @@ export function isEmployee(login: string, employeesSet: Set<string>): boolean {
 }
 
 export function isCommunityPR(authorLogin: string, employeesSet: Set<string>, authorAssociation?: string): boolean {
-  // Exclude bots (including Dependabot - note: dependabot shows as "dependabot", not "dependabot[bot]")
-  const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
+  const isBot = isBotLogin(authorLogin);
   
   // Exclude employees
   const isEmployeeUser = isEmployee(authorLogin, employeesSet);

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { config } from './config';
 import { cache } from './cache';
-import { getOrgMembersGraphQL, getOrgMembersREST } from './github';
+import { getOrgMembersGraphQL, getOrgMembersREST, getRepoMaintainersREST } from './github';
 import { EmployeeOverrides } from './types';
 
 function loadEmployeeOverrides(): EmployeeOverrides {
@@ -54,6 +54,19 @@ export async function buildEmployeesSet(): Promise<Set<string>> {
   });
 }
 
+export async function buildRepoMaintainersSet(owner: string, repo: string): Promise<Set<string>> {
+  const cacheKey = `maintainers:${owner}/${repo}`;
+
+  return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
+    try {
+      return new Set(await getRepoMaintainersREST(owner, repo));
+    } catch (error) {
+      console.error(`Failed to fetch maintainers for ${owner}/${repo}:`, error);
+      return new Set<string>();
+    }
+  });
+}
+
 export function isEmployee(login: string, employeesSet: Set<string>): boolean {
   return employeesSet.has(login);
 }
@@ -76,10 +89,18 @@ export function isCommunityPR(authorLogin: string, employeesSet: Set<string>, au
 
 export type AuthorType = 'employee' | 'maintainer' | 'community' | 'bot';
 
-export function getAuthorType(authorLogin: string, employeesSet: Set<string>, authorAssociation?: string): AuthorType {
+export function getAuthorType(
+  authorLogin: string,
+  employeesSet: Set<string>,
+  authorAssociation?: string,
+  maintainersSet: Set<string> = new Set()
+): AuthorType {
   // Check for bots first (including Dependabot)
   const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
   if (isBot) return 'bot';
+
+  // Prefer explicit repo maintainer membership so employee-maintainers show as maintainers.
+  if (maintainersSet.has(authorLogin)) return 'maintainer';
   
   // Check for employees (org members)
   const isEmployeeUser = isEmployee(authorLogin, employeesSet);

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { config } from './config';
 import { cache } from './cache';
-import { getOrgMembersGraphQL, getOrgMembersREST, getRepoMaintainersREST } from './github';
-import { EmployeeOverrides } from './types';
+import { getOrgMembersGraphQL, getOrgMembersREST, getRepoAuthorRoleSetsREST } from './github';
+import { EmployeeOverrides, RepoAuthorRoleSets } from './types';
 
 function loadEmployeeOverrides(): EmployeeOverrides {
   try {
@@ -54,15 +54,22 @@ export async function buildEmployeesSet(): Promise<Set<string>> {
   });
 }
 
-export async function buildRepoMaintainersSet(owner: string, repo: string): Promise<Set<string>> {
-  const cacheKey = `maintainers:${owner}/${repo}`;
+export async function buildRepoAuthorRoleSets(owner: string, repo: string): Promise<RepoAuthorRoleSets> {
+  const cacheKey = `repo-author-roles:${owner}/${repo}`;
 
   return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
     try {
-      return new Set(await getRepoMaintainersREST(owner, repo));
+      const roleSets = await getRepoAuthorRoleSetsREST(owner, repo);
+      return {
+        maintainers: new Set(roleSets.maintainers),
+        collaborators: new Set(roleSets.collaborators),
+      };
     } catch (error) {
-      console.error(`Failed to fetch maintainers for ${owner}/${repo}:`, error);
-      return new Set<string>();
+      console.error(`Failed to fetch repo author roles for ${owner}/${repo}:`, error);
+      return {
+        maintainers: new Set<string>(),
+        collaborators: new Set<string>(),
+      };
     }
   });
 }
@@ -87,30 +94,33 @@ export function isCommunityPR(authorLogin: string, employeesSet: Set<string>, au
   return !isBot && !isEmployeeUser && !hasWriteAccess;
 }
 
-export type AuthorType = 'employee' | 'maintainer' | 'community' | 'bot';
+export type AuthorType = 'employee' | 'maintainer' | 'collaborator' | 'community' | 'bot';
+
+function isBotLogin(login: string): boolean {
+  return login.includes('[bot]') || login.endsWith('-bot') || login.endsWith('_bot') || login === 'dependabot';
+}
+
+function isOrgMemberAssociation(authorAssociation?: string): boolean {
+  return authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
+}
 
 export function getAuthorType(
   authorLogin: string,
   employeesSet: Set<string>,
   authorAssociation?: string,
-  maintainersSet: Set<string> = new Set()
+  repoAuthorRoleSets: RepoAuthorRoleSets = { maintainers: new Set(), collaborators: new Set() }
 ): AuthorType {
-  // Check for bots first (including Dependabot)
-  const isBot = authorLogin.includes('[bot]') || authorLogin.endsWith('-bot') || authorLogin.endsWith('_bot') || authorLogin === 'dependabot';
-  if (isBot) return 'bot';
+  if (isBotLogin(authorLogin)) return 'bot';
 
-  // Prefer explicit repo maintainer membership so employee-maintainers show as maintainers.
-  if (maintainersSet.has(authorLogin)) return 'maintainer';
-  
-  // Check for employees (org members)
-  const isEmployeeUser = isEmployee(authorLogin, employeesSet);
+  if (repoAuthorRoleSets.maintainers.has(authorLogin)) return 'maintainer';
+
+  const isEmployeeUser = isEmployee(authorLogin, employeesSet) || isOrgMemberAssociation(authorAssociation);
   if (isEmployeeUser) return 'employee';
-  
-  // Check for maintainers (users with write access)
-  const hasWriteAccess = authorAssociation === 'COLLABORATOR' || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
-  if (hasWriteAccess) return 'maintainer';
-  
-  // Everyone else is community
+
+  if (repoAuthorRoleSets.collaborators.has(authorLogin) || authorAssociation === 'COLLABORATOR') {
+    return 'collaborator';
+  }
+
   return 'community';
 }
 

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -5,11 +5,24 @@ import { cache } from './cache';
 import { RateLimitError, getOrgMembersGraphQL, getOrgMembersREST, getRepoCollaboratorsREST } from './github';
 import { EmployeeOverrides, LoginOverrides, MaintainerOverrides, RepoAuthorRoleSets } from './types';
 
+function normalizeOverrides(data: unknown): LoginOverrides {
+  if (!data || typeof data !== 'object') {
+    return { allowlist: [], denylist: [] };
+  }
+
+  const record = data as Partial<LoginOverrides>;
+
+  return {
+    allowlist: Array.isArray(record.allowlist) ? record.allowlist.filter((value): value is string => typeof value === 'string') : [],
+    denylist: Array.isArray(record.denylist) ? record.denylist.filter((value): value is string => typeof value === 'string') : [],
+  };
+}
+
 function loadOverrides(fileName: string): LoginOverrides {
   try {
     const filePath = join(process.cwd(), 'config', fileName);
     const fileContent = readFileSync(filePath, 'utf-8');
-    return JSON.parse(fileContent);
+    return normalizeOverrides(JSON.parse(fileContent));
   } catch {
     return { allowlist: [], denylist: [] };
   }

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -79,44 +79,25 @@ export async function buildRepoAuthorRoleSets(owner: string, repo: string): Prom
   const cacheKey = `repo-author-roles:${owner}/${repo}`;
 
   return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
-    try {
-      const [maintainersSet, collaborators] = await Promise.all([
-        buildMaintainersSet(),
-        getRepoCollaboratorsREST(owner, repo),
-      ]);
+    const maintainersSet = await buildMaintainersSet();
+    let collaborators: string[] = [];
 
-      return {
-        maintainers: new Set(maintainersSet),
-        collaborators: new Set(collaborators.filter(login => !maintainersSet.has(login))),
-      };
+    try {
+      collaborators = await getRepoCollaboratorsREST(owner, repo);
     } catch (error) {
       if (error instanceof RateLimitError) throw error;
-      console.error(`Failed to fetch repo author roles for ${owner}/${repo}:`, error);
-      return {
-        maintainers: new Set<string>(),
-        collaborators: new Set<string>(),
-      };
+      console.error(`Failed to fetch repo collaborators for ${owner}/${repo}:`, error);
     }
+
+    return {
+      maintainers: new Set(maintainersSet),
+      collaborators: new Set(collaborators.filter(login => !maintainersSet.has(login))),
+    };
   });
 }
 
 export function isEmployee(login: string, employeesSet: Set<string>): boolean {
   return employeesSet.has(login);
-}
-
-export function isCommunityPR(authorLogin: string, employeesSet: Set<string>, authorAssociation?: string): boolean {
-  const isBot = isBotLogin(authorLogin);
-  
-  // Exclude employees
-  const isEmployeeUser = isEmployee(authorLogin, employeesSet);
-  
-  // Exclude repository maintainers/collaborators (these have write access and are not community)
-  // COLLABORATOR = has write access, MEMBER = org member, OWNER = repo owner
-  const hasWriteAccess = authorAssociation === 'COLLABORATOR' || authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
-  
-  // Community PRs are from external contributors without write access
-  // This includes: CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE
-  return !isBot && !isEmployeeUser && !hasWriteAccess;
 }
 
 export type AuthorType = 'employee' | 'maintainer' | 'collaborator' | 'community' | 'bot';
@@ -125,7 +106,7 @@ function isBotLogin(login: string): boolean {
   return login.includes('[bot]') || login.endsWith('-bot') || login.endsWith('_bot') || login === 'dependabot';
 }
 
-function isOrgMemberAssociation(authorAssociation?: string): boolean {
+export function isOrgMemberAssociation(authorAssociation?: string): boolean {
   return authorAssociation === 'MEMBER' || authorAssociation === 'OWNER';
 }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -150,11 +150,7 @@ export async function getOrgMembersREST(org: string): Promise<string[]> {
   return members;
 }
 
-export async function getRepoAuthorRoleSetsREST(
-  owner: string,
-  repo: string
-): Promise<{ maintainers: string[]; collaborators: string[] }> {
-  const maintainers = new Set<string>();
+export async function getRepoCollaboratorsREST(owner: string, repo: string): Promise<string[]> {
   const collaborators = new Set<string>();
   let page = 1;
   let hasMore = true;
@@ -171,9 +167,7 @@ export async function getRepoAuthorRoleSetsREST(
     } else {
       data.forEach((collaborator: any) => {
         const permissions = collaborator.permissions || {};
-        if (permissions.admin || permissions.maintain) {
-          maintainers.add(collaborator.login);
-        } else if (permissions.push) {
+        if (permissions.admin || permissions.maintain || permissions.push) {
           collaborators.add(collaborator.login);
         }
       });
@@ -181,10 +175,7 @@ export async function getRepoAuthorRoleSetsREST(
     }
   }
 
-  return {
-    maintainers: Array.from(maintainers),
-    collaborators: Array.from(collaborators),
-  };
+  return Array.from(collaborators);
 }
 
 export async function getOpenPRsGraphQL(owner: string, repo: string): Promise<any[]> {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -150,6 +150,34 @@ export async function getOrgMembersREST(org: string): Promise<string[]> {
   return members;
 }
 
+export async function getRepoMaintainersREST(owner: string, repo: string): Promise<string[]> {
+  const maintainers = new Set<string>();
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore) {
+    const response = await fetchGitHub(
+      `https://api.github.com/repos/${owner}/${repo}/collaborators?affiliation=all&per_page=100&page=${page}`
+    );
+
+    const data = await response.json();
+
+    if (data.length === 0) {
+      hasMore = false;
+    } else {
+      data.forEach((collaborator: any) => {
+        const permissions = collaborator.permissions || {};
+        if (permissions.admin || permissions.maintain || permissions.push) {
+          maintainers.add(collaborator.login);
+        }
+      });
+      page++;
+    }
+  }
+
+  return Array.from(maintainers);
+}
+
 export async function getOpenPRsGraphQL(owner: string, repo: string): Promise<any[]> {
   const query = `
     query OpenPRs($owner: String!, $name: String!, $cursor: String) {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -150,8 +150,12 @@ export async function getOrgMembersREST(org: string): Promise<string[]> {
   return members;
 }
 
-export async function getRepoMaintainersREST(owner: string, repo: string): Promise<string[]> {
+export async function getRepoAuthorRoleSetsREST(
+  owner: string,
+  repo: string
+): Promise<{ maintainers: string[]; collaborators: string[] }> {
   const maintainers = new Set<string>();
+  const collaborators = new Set<string>();
   let page = 1;
   let hasMore = true;
 
@@ -167,15 +171,20 @@ export async function getRepoMaintainersREST(owner: string, repo: string): Promi
     } else {
       data.forEach((collaborator: any) => {
         const permissions = collaborator.permissions || {};
-        if (permissions.admin || permissions.maintain || permissions.push) {
+        if (permissions.admin || permissions.maintain) {
           maintainers.add(collaborator.login);
+        } else if (permissions.push) {
+          collaborators.add(collaborator.login);
         }
       });
       page++;
     }
   }
 
-  return Array.from(maintainers);
+  return {
+    maintainers: Array.from(maintainers),
+    collaborators: Array.from(collaborators),
+  };
 }
 
 export async function getOpenPRsGraphQL(owner: string, repo: string): Promise<any[]> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,7 +18,7 @@ export type PR = {
   url: string;
   authorLogin: string;
   authorAssociation: string;
-  authorType: 'employee' | 'maintainer' | 'community' | 'bot';
+  authorType: 'employee' | 'maintainer' | 'collaborator' | 'community' | 'bot';
   isEmployeeAuthor: boolean;
   isDraft: boolean;
   createdAt: string;
@@ -61,6 +61,11 @@ export type ReviewStatsResponse = {
 export type EmployeeOverrides = {
   allowlist: string[];
   denylist: string[];
+};
+
+export type RepoAuthorRoleSets = {
+  maintainers: Set<string>;
+  collaborators: Set<string>;
 };
 
 export type GitHubRateLimit = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,10 +58,13 @@ export type ReviewStatsResponse = {
   uniqueReviewersWithPending: number;
 };
 
-export type EmployeeOverrides = {
+export type LoginOverrides = {
   allowlist: string[];
   denylist: string[];
 };
+
+export type EmployeeOverrides = LoginOverrides;
+export type MaintainerOverrides = LoginOverrides;
 
 export type RepoAuthorRoleSets = {
   maintainers: Set<string>;


### PR DESCRIPTION
## Summary

This PR proposes to display Open Source maintainers, whether they are AH employees or not, then fall back to other roles.

## Details
- use `config/maintainers.json` as the maintainer source of truth, following the existing config override pattern already used for employees
- apply precedence as `bot > maintainer > employee > collaborator > community`
- keep repo collaborators derived from GitHub collaborator access so non-maintainer write-access users still show separately from community
- update community PR calculations to rely on the transformed author type
- add tests for explicit maintainer config and collaborator separation

## Verification
- `npm test -- --runInBand __tests__/lib/authorRoles.test.ts __tests__/lib/employees.test.ts __tests__/lib/compute.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand __tests__/api/dashboard.test.ts __tests__/components/PrTable.test.tsx`
- `npm run build`

Supersedes the fork-only review PR at `enyst/oh-community-pr-dashboard#2`.

_This PR was created and updated by an AI assistant (OpenHands) on behalf of the user._
