### PR TITLE
Add missing maintainer logins

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -9,6 +9,8 @@
     "enyst",
     "mamoodi",
     "li-boxuan",
+    "raymyers",
+    "jpshackelford",
     "tobitege"
   ],
   "denylist": []


### PR DESCRIPTION
## Summary
- add `raymyers` and `jpshackelford` to the explicit maintainer allowlist

## Why
The dashboard treats `config/maintainers.json` as the maintainer source of truth, and these two logins were simply missing from that file. I also verified their canonical GitHub logins are already lowercase, so this was an allowlist omission rather than a casing issue.

## Validation
- parsed `config/maintainers.json` and confirmed both logins are present

_This PR was created by an AI assistant (OpenHands) on behalf of the user._