### PR TITLE
Implement issue #34 dashboard default view updates

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,7 +7,7 @@ GITHUB_TOKEN=your_github_token_here
 
 # Organization and Repository Configuration
 # Comma-separated list of organizations to scan
-ORGS=All-Hands-AI,OpenHands
+ORGS=OpenHands
 
 # Optional: Specific repositories to include (owner/repo format)
 # If empty, will auto-discover repositories from the organizations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,7 @@ npm run test:watch   # Run Jest in watch mode
 - Bot accounts should be filtered out of reviewer-facing metrics and requested-reviewer lists; author bot classification alone is not enough to remove bot reviewers from the dashboard.
 - Production HTML includes the deployed git SHA in a comment near the top of the document, which is useful for checking whether Vercel is serving the latest commit.
 - `__tests__/api/dashboard.test.ts` may need a larger Node heap in this environment; `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand __tests__/api/dashboard.test.ts` worked reliably.
+- Default repo scope is resolved dynamically in `lib/defaults.ts` by discovering all public repos for `config.orgs`; the dashboard client uses an empty repository filter to mean “all configured repos”.
+- Employee detection is sourced from `OpenHands/champions-list/data/excluded-logins.json` with `config/employees.json` still available for local allowlist/denylist overrides; maintainer overrides remain in `config/maintainers.json`.
+- The default dashboard view is intentionally narrowed to PRs ready for review in the last 7 days, with `status=needs-review` and `draftStatus=final`; the API supports `startDate` and `endDate` query params that filter on `readyForReviewAt`.
+

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Visit [http://localhost:3000/api/test](http://localhost:3000/api/test) to verify
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `GITHUB_TOKEN` | GitHub Personal Access Token | Required |
-| `ORGS` | Comma-separated list of GitHub organizations | `All-Hands-AI` |
+| `ORGS` | Comma-separated list of GitHub organizations | `OpenHands` |
 | `REPOS_INCLUDE` | Specific repositories to include (owner/repo format) | Auto-discover |
 | `REPOS_EXCLUDE` | Repositories to exclude from auto-discovery | None |
 | `SLA_HOURS_FIRST_RESPONSE` | SLA for first human response (hours) | `24` |
@@ -69,7 +69,7 @@ Visit [http://localhost:3000/api/test](http://localhost:3000/api/test) to verify
 
 ### Employee Configuration
 
-Edit `config/employees.json` to override employee detection:
+Employee detection is sourced from `OpenHands/champions-list/data/excluded-logins.json`, with `config/employees.json` available for local allowlist or denylist overrides:
 
 ```json
 {

--- a/__tests__/api/dashboard.test.ts
+++ b/__tests__/api/dashboard.test.ts
@@ -38,6 +38,10 @@ jest.mock('@/lib/cache', () => ({
   },
 }));
 
+jest.mock('@/lib/defaults', () => ({
+  getDefaultRepos: jest.fn(),
+}));
+
 jest.mock('@/lib/employees', () => ({
   buildEmployeesSet: jest.fn(),
   buildRepoAuthorRoleSets: jest.fn(),
@@ -72,6 +76,7 @@ import {
   getAllPRReviewStats,
 } from '@/lib/github';
 import { buildEmployeesSet, buildRepoAuthorRoleSets } from '@/lib/employees';
+import { getDefaultRepos } from '@/lib/defaults';
 import {
   transformPR,
   computeDashboardData,
@@ -83,6 +88,7 @@ import {
 const mockGetOpenPRs        = getOpenPRsGraphQL               as jest.MockedFunction<typeof getOpenPRsGraphQL>;
 const mockGetMergedPRs      = getRecentlyMergedPRsWithReviews as jest.MockedFunction<typeof getRecentlyMergedPRsWithReviews>;
 const mockGetAllReviewStats = getAllPRReviewStats             as jest.MockedFunction<typeof getAllPRReviewStats>;
+const mockGetDefaultRepos   = getDefaultRepos                 as jest.MockedFunction<typeof getDefaultRepos>;
 const mockBuildEmployeesSet = buildEmployeesSet               as jest.MockedFunction<typeof buildEmployeesSet>;
 const mockBuildRepoAuthorRoleSets = buildRepoAuthorRoleSets   as jest.MockedFunction<typeof buildRepoAuthorRoleSets>;
 const mockTransformPR             = transformPR               as jest.MockedFunction<typeof transformPR>;
@@ -106,6 +112,7 @@ function makeTransformedPR(overrides: Record<string, unknown> = {}) {
     labels: [],
     authorType: 'community',
     ageHours: 0,
+    readyForReviewAt: '2026-06-10T12:00:00Z',
     needsFirstResponse: false,
     firstReviewAt: null,
     isDraft: false,
@@ -134,6 +141,7 @@ const EMPTY_DASHBOARD_DATA = {
 beforeEach(() => {
   jest.clearAllMocks();
 
+  mockGetDefaultRepos.mockResolvedValue(['OpenHands/OpenHands', 'OpenHands/docs']);
   mockBuildEmployeesSet.mockResolvedValue(new Set<string>());
   mockBuildRepoAuthorRoleSets.mockResolvedValue({ maintainers: new Set<string>(), collaborators: new Set<string>() });
   mockGetOpenPRs.mockResolvedValue([]);
@@ -165,17 +173,17 @@ describe('GET /api/dashboard — resolveRepos', () => {
     expect(mockGetOpenPRs).toHaveBeenCalledWith('owner', 'beta');
   });
 
-  it('uses DEFAULT_REPOS when no repos param is supplied', async () => {
+  it('uses getDefaultRepos when no repos param is supplied', async () => {
+    mockGetDefaultRepos.mockResolvedValueOnce(['OpenHands/OpenHands', 'OpenHands/community-pr-dashboard']);
+
     const res = await GET(makeRequest());
 
     expect(res.status).toBe(200);
+    expect(mockGetDefaultRepos).toHaveBeenCalledTimes(1);
     const fetched = mockGetOpenPRs.mock.calls.map(([owner, repo]) => `${owner}/${repo}`);
     expect(fetched).toEqual([
       'OpenHands/OpenHands',
-      'OpenHands/software-agent-sdk',
-      'OpenHands/OpenHands-CLI',
-      'OpenHands/docs',
-      'OpenHands/benchmarks',
+      'OpenHands/community-pr-dashboard',
     ]);
   });
 });
@@ -204,6 +212,26 @@ describe('GET /api/dashboard — parallel fetch', () => {
 
     expect(res.status).toBe(200);
     expect(body.totalPrs).toBe(3);
+  });
+});
+
+describe('GET /api/dashboard — date filtering', () => {
+  it('filters PRs by ready-for-review date range when startDate and endDate are provided', async () => {
+    mockGetOpenPRs.mockResolvedValue([{ number: 1 }, { number: 2 }]);
+    mockTransformPR
+      .mockImplementationOnce(() => makeTransformedPR({ number: 1, readyForReviewAt: '2026-06-10T12:00:00Z' }) as any)
+      .mockImplementationOnce(() => makeTransformedPR({ number: 2, readyForReviewAt: '2026-05-20T12:00:00Z' }) as any);
+
+    const res = await GET(makeRequest({
+      repos: 'owner/repo1',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.prs).toHaveLength(1);
+    expect(body.prs[0].number).toBe(1);
   });
 });
 

--- a/__tests__/lib/authorRoles.test.ts
+++ b/__tests__/lib/authorRoles.test.ts
@@ -24,16 +24,18 @@ jest.mock('@/lib/github', () => ({
     }
     resetAt: string;
   },
+  getExcludedLogins: jest.fn(),
   getOrgMembersGraphQL: jest.fn(),
   getOrgMembersREST: jest.fn(),
   getRepoCollaboratorsREST: jest.fn(),
 }));
 
 import { readFileSync } from 'fs';
-import { getOrgMembersGraphQL, getRepoCollaboratorsREST } from '@/lib/github';
+import { getExcludedLogins, getOrgMembersGraphQL, getRepoCollaboratorsREST } from '@/lib/github';
 import { buildEmployeesSet, buildMaintainersSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 
 const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+const mockGetExcludedLogins = getExcludedLogins as jest.MockedFunction<typeof getExcludedLogins>;
 const mockGetOrgMembersGraphQL = getOrgMembersGraphQL as jest.MockedFunction<typeof getOrgMembersGraphQL>;
 const mockGetRepoCollaboratorsREST = getRepoCollaboratorsREST as jest.MockedFunction<typeof getRepoCollaboratorsREST>;
 
@@ -60,6 +62,11 @@ beforeEach(() => {
     throw new Error(`Unexpected file read: ${pathString}`);
   });
 
+  mockGetExcludedLogins.mockResolvedValue([
+    { login: 'org-employee', reason: 'employee or org member' },
+    { login: 'removed-employee', reason: 'employee or org member' },
+    { login: 'renovate', reason: 'bot denylist' },
+  ]);
   mockGetOrgMembersGraphQL.mockResolvedValue(['org-employee', 'removed-employee']);
   mockGetRepoCollaboratorsREST.mockResolvedValue(['enyst', 'rbren', 'write-user']);
 });
@@ -70,6 +77,16 @@ describe('override-backed author role builders', () => {
 
     expect(employees).toEqual(new Set(['org-employee', 'added-employee']));
   });
+
+  it('falls back to org membership when the excluded-login source is unavailable', async () => {
+    mockGetExcludedLogins.mockRejectedValueOnce(new Error('source unavailable'));
+
+    const employees = await buildEmployeesSet();
+
+    expect(employees).toEqual(new Set(['org-employee', 'added-employee']));
+    expect(mockGetOrgMembersGraphQL).toHaveBeenCalledWith('test-org');
+  });
+
 
   it('applies maintainer allowlist and denylist overrides', async () => {
     const maintainers = await buildMaintainersSet();

--- a/__tests__/lib/employees.test.ts
+++ b/__tests__/lib/employees.test.ts
@@ -27,6 +27,12 @@ describe('getAuthorType', () => {
     expect(getAuthorType('dependabot[bot]', employeesSet, 'NONE', repoAuthorRoleSets)).toBe('bot');
   });
 
+  it('classifies explicitly listed bot accounts as bot', () => {
+    expect(getAuthorType('openhands', employeesSet, 'NONE', repoAuthorRoleSets)).toBe('bot');
+    expect(getAuthorType('smolpaws', employeesSet, 'NONE', repoAuthorRoleSets)).toBe('bot');
+  });
+
+
   it('uses MEMBER association as a fallback employee signal', () => {
     expect(getAuthorType('member-only', new Set(), 'MEMBER', repoAuthorRoleSets)).toBe('employee');
   });

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -5,12 +5,22 @@ import { buildEmployeesSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 import { RateLimitError, getOpenPRsGraphQL, getRecentlyMergedPRsWithReviews, getAllPRReviewStats, ReviewStatsData, CommunityPRReviewData, OrgMemberPRReviewData, BotPRReviewData } from '@/lib/github';
 import { transformPR, computeDashboardData, computeCommunityReviewerStats, computeOrgMemberReviewerStats, computeBotReviewerStats } from '@/lib/compute';
 import { PR } from '@/lib/types';
-import { DEFAULT_REPOS } from '@/lib/defaults';
+import { getDefaultRepos } from '@/lib/defaults';
 
 export const dynamic = 'force-dynamic';
 
-function resolveRepos(targetRepos: string[]): string[] {
-  return targetRepos.length > 0 ? targetRepos : DEFAULT_REPOS;
+async function resolveRepos(targetRepos: string[]): Promise<string[]> {
+  return targetRepos.length > 0 ? targetRepos : getDefaultRepos();
+}
+
+function parseDateBoundary(dateValue: string | null, endOfDay = false): number | null {
+  if (!dateValue) {
+    return null;
+  }
+
+  const isoDate = `${dateValue}T${endOfDay ? '23:59:59.999' : '00:00:00.000'}Z`;
+  const timestamp = new Date(isoDate).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
 }
 
 export async function GET(request: NextRequest) {
@@ -20,6 +30,8 @@ export async function GET(request: NextRequest) {
     const reposParam = searchParams.get('repos');
     const labelsParam = searchParams.get('labels');
     const ageParam = searchParams.get('age');
+    const startDateParam = searchParams.get('startDate');
+    const endDateParam = searchParams.get('endDate');
     const statusParam = searchParams.get('status');
     const noReviewersParam = searchParams.get('noReviewers');
     const limitParam = searchParams.get('limit');
@@ -27,25 +39,23 @@ export async function GET(request: NextRequest) {
     const authorTypeParam = searchParams.get('authorType');
     const reviewerParam = searchParams.get('reviewer');
 
-    // Parse filters
     const targetRepos = reposParam
-      ? reposParam.split(',').map(r => r.trim())
-      : config.repos.include.length > 0
-        ? config.repos.include
-        : []; // Will auto-discover if empty
+      ? reposParam.split(',').map(r => r.trim()).filter(Boolean)
+      : [];
 
     const labelFilters = labelsParam
-      ? labelsParam.split(',').map(l => l.trim().toLowerCase())
+      ? labelsParam.split(',').map(l => l.trim().toLowerCase()).filter(Boolean)
       : [];
 
     const cacheBustParam = searchParams.get('cacheBust');
 
-    // Create cache key based on filters
     const cacheKey = `dashboard:${JSON.stringify({
       orgs: config.orgs,
       repos: targetRepos,
       labels: labelFilters,
       age: ageParam,
+      startDate: startDateParam,
+      endDate: endDateParam,
       status: statusParam,
       noReviewers: noReviewersParam,
       limit: limitParam,
@@ -56,7 +66,7 @@ export async function GET(request: NextRequest) {
     })}`;
 
     const result = await cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
-      const reposToFetch = resolveRepos(targetRepos);
+      const reposToFetch = await resolveRepos(targetRepos);
       const employeesSet = await buildEmployeesSet();
 
       // Phase 2: for every repo, run its three fetches in parallel; run all repos in parallel.
@@ -132,6 +142,30 @@ export async function GET(request: NextRequest) {
       if (authorTypeParam && authorTypeParam !== 'all') {
         filteredPrs = filteredPrs.filter(pr => pr.authorType === authorTypeParam);
       }
+
+      const startDateBoundary = parseDateBoundary(startDateParam);
+      const endDateBoundary = parseDateBoundary(endDateParam, true);
+
+      if (startDateBoundary !== null || endDateBoundary !== null) {
+        filteredPrs = filteredPrs.filter(pr => {
+          const readyForReviewTime = new Date(pr.readyForReviewAt).getTime();
+
+          if (Number.isNaN(readyForReviewTime)) {
+            return false;
+          }
+
+          if (startDateBoundary !== null && readyForReviewTime < startDateBoundary) {
+            return false;
+          }
+
+          if (endDateBoundary !== null && readyForReviewTime > endDateBoundary) {
+            return false;
+          }
+
+          return true;
+        });
+      }
+
 
       // Apply age filter if provided
       if (ageParam && ageParam !== 'all') {
@@ -293,7 +327,13 @@ export async function GET(request: NextRequest) {
         totalPrs: result.totalPrs,
         employeeCount: result.employeeCount,
         cacheKey,
-        filters: { repos: targetRepos, labels: labelFilters, age: ageParam },
+        filters: {
+          repos: targetRepos,
+          labels: labelFilters,
+          age: ageParam,
+          startDate: startDateParam,
+          endDate: endDateParam,
+        },
       };
     }
 

--- a/app/api/repositories/route.ts
+++ b/app/api/repositories/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Octokit } from '@octokit/rest'
+import { config } from '@/lib/config'
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
 })
 
-// Organizations to fetch repositories from
-const TARGET_ORGS = ['all-hands-ai', 'openhands']
+const excludedRepos = new Set(config.repos.exclude.map(repo => repo.trim().toLowerCase()))
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     const specificOrg = searchParams.get('org')
 
     // Determine which organizations to fetch from
-    const orgsToFetch = specificOrg ? [specificOrg] : TARGET_ORGS
+    const orgsToFetch = specificOrg ? [specificOrg] : config.orgs
 
     console.log('Fetching repositories from organizations:', orgsToFetch)
 
@@ -61,19 +61,23 @@ export async function GET(request: NextRequest) {
     }
 
     // Filter and format repositories
-    const formattedRepos = allRepositories
-      .filter(repo => !repo.archived && !repo.disabled)
-      .map(repo => ({
-        id: repo.id,
-        name: repo.name,
-        full_name: repo.full_name,
-        description: repo.description,
-        stargazers_count: repo.stargazers_count,
-        language: repo.language,
-        updated_at: repo.updated_at,
-        html_url: repo.html_url,
-      }))
-      .sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0)) // Sort by stars
+    const formattedRepos = Array.from(
+      new Map(
+        allRepositories
+          .filter(repo => !repo.archived && !repo.disabled)
+          .filter(repo => !excludedRepos.has(repo.full_name.toLowerCase()))
+          .map(repo => [repo.full_name.toLowerCase(), {
+            id: repo.id,
+            name: repo.name,
+            full_name: repo.full_name,
+            description: repo.description,
+            stargazers_count: repo.stargazers_count,
+            language: repo.language,
+            updated_at: repo.updated_at,
+            html_url: repo.html_url,
+          }])
+      ).values()
+    ).sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0)) // Sort by stars
 
     console.log(`Total formatted repositories: ${formattedRepos.length}`)
 
@@ -90,49 +94,39 @@ export async function GET(request: NextRequest) {
       {
         id: 1,
         name: 'OpenHands',
-        full_name: 'all-hands-ai/OpenHands',
+        full_name: 'OpenHands/OpenHands',
         description: 'OpenHands: Code Less, Make More',
         stargazers_count: 35000,
         language: 'Python',
         updated_at: new Date().toISOString(),
-        html_url: 'https://github.com/all-hands-ai/OpenHands',
+        html_url: 'https://github.com/OpenHands/OpenHands',
       },
       {
         id: 2,
-        name: 'agent-sdk',
-        full_name: 'all-hands-ai/agent-sdk',
-        description: 'SDK for building AI agents',
-        stargazers_count: 500,
+        name: 'community-pr-dashboard',
+        full_name: 'OpenHands/community-pr-dashboard',
+        description: 'Dashboard for tracking community pull requests and review accountability',
+        stargazers_count: 0,
         language: 'TypeScript',
         updated_at: new Date().toISOString(),
-        html_url: 'https://github.com/all-hands-ai/agent-sdk',
+        html_url: 'https://github.com/OpenHands/community-pr-dashboard',
       },
       {
         id: 3,
-        name: 'SWE-bench',
-        full_name: 'all-hands-ai/SWE-bench',
-        description: 'Enhanced fork of SWE-bench, tailored for OpenHands ecosystem',
-        stargazers_count: 1000,
-        language: 'Python',
+        name: 'docs',
+        full_name: 'OpenHands/docs',
+        description: 'OpenHands documentation site',
+        stargazers_count: 0,
+        language: 'TypeScript',
         updated_at: new Date().toISOString(),
-        html_url: 'https://github.com/all-hands-ai/SWE-bench',
-      },
-      {
-        id: 4,
-        name: 'OpenHands-Cloud',
-        full_name: 'all-hands-ai/OpenHands-Cloud',
-        description: 'All Hands AI OpenHands Self-hosted Cloud',
-        stargazers_count: 200,
-        language: 'Smarty',
-        updated_at: new Date().toISOString(),
-        html_url: 'https://github.com/all-hands-ai/OpenHands-Cloud',
+        html_url: 'https://github.com/OpenHands/docs',
       },
     ]
 
     return NextResponse.json({
-      repositories: fallbackRepos,
-      total: fallbackRepos.length,
-      organizations: TARGET_ORGS,
+      repositories: fallbackRepos.filter(repo => !excludedRepos.has(repo.full_name.toLowerCase())),
+      total: fallbackRepos.filter(repo => !excludedRepos.has(repo.full_name.toLowerCase())).length,
+      organizations: config.orgs,
       error: 'Using fallback data due to API error',
     })
   }

--- a/app/api/review-stats/route.ts
+++ b/app/api/review-stats/route.ts
@@ -7,7 +7,7 @@ import { buildEmployeesSet, buildRepoAuthorRoleSets } from '@/lib/employees';
 import { getOpenPRsGraphQL } from '@/lib/github';
 import { transformPR, computeReviewStats } from '@/lib/compute';
 import { PR } from '@/lib/types';
-import { DEFAULT_REPOS } from '@/lib/defaults';
+import { getDefaultRepos } from '@/lib/defaults';
 
 export async function GET(_request: NextRequest) {
   try {
@@ -22,7 +22,7 @@ export async function GET(_request: NextRequest) {
       // Get all PRs from configured repositories
       const allPrs: PR[] = [];
       
-      const reposToFetch = config.repos.include.length > 0 ? config.repos.include : DEFAULT_REPOS;
+      const reposToFetch = await getDefaultRepos();
       
       for (const repoPath of reposToFetch) {
         const [owner, repo] = repoPath.split('/');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,39 @@ import DashboardSkeleton from '@/components/DashboardSkeleton'
 import WhatsNew from '@/components/WhatsNew'
 import { Tooltip } from '@/components/Tooltip'
 import { DashboardData, FilterState } from '@/lib/types'
-import { DEFAULT_REPOS } from '@/lib/defaults'
+
+function formatDateInput(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function getDefaultDateRange() {
+  const endDate = new Date()
+  const startDate = new Date(endDate)
+  startDate.setUTCDate(startDate.getUTCDate() - 6)
+
+  return {
+    startDate: formatDateInput(startDate),
+    endDate: formatDateInput(endDate),
+  }
+}
+
+function createDefaultFilters(): FilterState {
+  const { startDate, endDate } = getDefaultDateRange()
+
+  return {
+    repositories: [],
+    labels: [],
+    ageRange: 'all',
+    startDate,
+    endDate,
+    status: 'needs-review',
+    noReviewers: false,
+    limit: 'all',
+    draftStatus: 'final',
+    authorType: 'all',
+    reviewer: 'all'
+  }
+}
 
 export default function Dashboard() {
   const [data, setData] = useState<DashboardData | null>(null)
@@ -19,28 +51,8 @@ export default function Dashboard() {
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const [allReviewers, setAllReviewers] = useState<string[]>([])
 
-  const [filters, setFilters] = useState<FilterState>({
-    repositories: DEFAULT_REPOS,
-    labels: [],
-    ageRange: 'all', // Default to All Time - no filtering
-    status: 'all',
-    noReviewers: false,
-    limit: 'all',
-    draftStatus: 'all',
-    authorType: 'all',
-    reviewer: 'all'
-  })
-  const [appliedFilters, setAppliedFilters] = useState<FilterState>({
-    repositories: DEFAULT_REPOS,
-    labels: [],
-    ageRange: 'all', // Default to All Time - no filtering
-    status: 'all',
-    noReviewers: false,
-    limit: 'all',
-    draftStatus: 'all',
-    authorType: 'all',
-    reviewer: 'all'
-  })
+  const [filters, setFilters] = useState<FilterState>(() => createDefaultFilters())
+  const [appliedFilters, setAppliedFilters] = useState<FilterState>(() => createDefaultFilters())
 
   const fetchData = useCallback(async (filtersToApply?: FilterState, { cacheBust = false } = {}) => {
     const targetFilters = filtersToApply || appliedFilters
@@ -58,6 +70,12 @@ export default function Dashboard() {
       }
       if (targetFilters.ageRange !== 'all') {
         params.append('age', targetFilters.ageRange)
+      }
+      if (targetFilters.startDate) {
+        params.append('startDate', targetFilters.startDate)
+      }
+      if (targetFilters.endDate) {
+        params.append('endDate', targetFilters.endDate)
       }
       if (targetFilters.status && targetFilters.status !== 'all') {
         params.append('status', targetFilters.status)
@@ -138,17 +156,7 @@ export default function Dashboard() {
   }, [fetchData])
 
   const handleClearFilters = () => {
-    const clearedFilters = {
-      repositories: [],
-      labels: [],
-      ageRange: 'all', // Default to All Time - no filtering
-      status: 'all',
-      noReviewers: false,
-      limit: 'all',
-      draftStatus: 'all',
-      authorType: 'all',
-      reviewer: 'all'
-    }
+    const clearedFilters = createDefaultFilters()
     setFilters(clearedFilters)
     setAppliedFilters(clearedFilters)
     fetchData(clearedFilters)
@@ -481,7 +489,7 @@ export default function Dashboard() {
         <section className="py-6">
           <div className={`${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'} border rounded-lg p-5 shadow-sm`}>
             <h3 className={`text-sm font-semibold mb-4 ${darkMode ? 'text-white' : 'text-gray-900'}`}>Filters</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-8 gap-4 mb-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-9 gap-4 mb-4">
               <div className="flex flex-col">
                 <label className={`text-sm font-medium mb-1.5 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Repository</label>
                 <RepositorySelector
@@ -498,25 +506,40 @@ export default function Dashboard() {
               </div>
 
               <div className="flex flex-col">
-                <label className={`text-sm font-medium mb-1.5 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Age</label>
-                <CustomDropdown
-                  options={[
-                    { value: 'all', label: 'All Time' },
-                    { value: '0-24', label: '0-24 hours' },
-                    { value: '2-days', label: 'Last 2 days' },
-                    { value: '3-days', label: 'Last 3 days' },
-                    { value: '7-days', label: 'Last 7 days' },
-                    { value: '30-days', label: 'Last 30 days' }
-                  ]}
-                  value={filters.ageRange}
-                  onChange={(value) => {
-                    const newFilters = { ...filters, ageRange: value as string }
+                <label className={`text-sm font-medium mb-1.5 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Ready From</label>
+                <input
+                  type="date"
+                  className={`px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+                    darkMode
+                      ? 'bg-gray-700 border-gray-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-900'
+                  }`}
+                  value={filters.startDate || ''}
+                  onChange={(e) => {
+                    const newFilters = { ...filters, startDate: e.target.value, ageRange: 'all' }
                     setFilters(newFilters)
                     setAppliedFilters(newFilters)
                     fetchData(newFilters)
                   }}
-                  placeholder="All Time"
-                  darkMode={darkMode}
+                />
+              </div>
+
+              <div className="flex flex-col">
+                <label className={`text-sm font-medium mb-1.5 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Ready To</label>
+                <input
+                  type="date"
+                  className={`px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+                    darkMode
+                      ? 'bg-gray-700 border-gray-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-900'
+                  }`}
+                  value={filters.endDate || ''}
+                  onChange={(e) => {
+                    const newFilters = { ...filters, endDate: e.target.value, ageRange: 'all' }
+                    setFilters(newFilters)
+                    setAppliedFilters(newFilters)
+                    fetchData(newFilters)
+                  }}
                 />
               </div>
 

--- a/components/RepositorySelector.tsx
+++ b/components/RepositorySelector.tsx
@@ -67,17 +67,17 @@ export default function RepositorySelector({ value, onChange, className = '', da
         {
           id: 1,
           name: 'OpenHands',
-          full_name: 'All-Hands-AI/OpenHands',
+          full_name: 'OpenHands/OpenHands',
           description: 'OpenHands: Code Less, Make More',
           stargazers_count: 35000,
           language: 'Python'
         },
         {
           id: 2,
-          name: 'agent-sdk',
-          full_name: 'All-Hands-AI/agent-sdk',
-          description: 'SDK for building AI agents',
-          stargazers_count: 500,
+          name: 'community-pr-dashboard',
+          full_name: 'OpenHands/community-pr-dashboard',
+          description: 'Dashboard for community PR review accountability',
+          stargazers_count: 0,
           language: 'TypeScript'
         }
       ])

--- a/config/employees.json
+++ b/config/employees.json
@@ -1,6 +1,4 @@
 {
-  "allowlist": [
-    "openhands"
-  ],
+  "allowlist": [],
   "denylist": []
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -9,7 +9,6 @@
     "enyst",
     "mamoodi",
     "li-boxuan",
-    "raymyers",
     "jpshackelford",
     "tobitege"
   ],

--- a/lib/bots.ts
+++ b/lib/bots.ts
@@ -1,10 +1,29 @@
+const KNOWN_BOT_LOGINS = new Set([
+  'all-hands-bot',
+  'blacksmith-sh[bot]',
+  'claudecode',
+  'codex',
+  'copilot',
+  'dependabot',
+  'dependabot[bot]',
+  'fly-io[bot]',
+  'github-actions',
+  'github-actions[bot]',
+  'openhands',
+  'openhands-bot',
+  'openhands-release-bot[bot]',
+  'renovate',
+  'renovate[bot]',
+  'smolpaws',
+]);
+
 export function isBotLogin(login?: string | null): boolean {
   if (!login) return false;
 
   const normalizedLogin = login.toLowerCase();
 
-  return normalizedLogin.includes('[bot]')
+  return KNOWN_BOT_LOGINS.has(normalizedLogin)
+    || normalizedLogin.includes('[bot]')
     || normalizedLogin.endsWith('-bot')
-    || normalizedLogin.endsWith('_bot')
-    || normalizedLogin === 'dependabot';
+    || normalizedLogin.endsWith('_bot');
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,7 +2,7 @@ export const config = {
   github: {
     token: process.env.GITHUB_TOKEN || '',
   },
-  orgs: (process.env.ORGS || 'all-hands-ai,openhands').split(',').map(s => s.trim()),
+  orgs: (process.env.ORGS || 'OpenHands').split(',').map(s => s.trim()).filter(Boolean),
   repos: {
     include: process.env.REPOS_INCLUDE
       ? process.env.REPOS_INCLUDE.split(',').map(s => s.trim())

--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -1,7 +1,41 @@
-export const DEFAULT_REPOS = [
+import { cache } from './cache';
+import { config } from './config';
+import { getAllRepositoriesFromOrgs } from './github';
+
+export const FALLBACK_REPOS = [
   'OpenHands/OpenHands',
-  'OpenHands/software-agent-sdk',
-  'OpenHands/OpenHands-CLI',
+  'OpenHands/community-pr-dashboard',
   'OpenHands/docs',
   'OpenHands/benchmarks',
+  'OpenHands/OpenHands-CLI',
 ];
+
+function normalizeRepo(repo: string): string {
+  return repo.trim().toLowerCase();
+}
+
+function filterExcludedRepos(repos: string[]): string[] {
+  if (config.repos.exclude.length === 0) {
+    return repos;
+  }
+
+  const excludedRepos = new Set(config.repos.exclude.map(normalizeRepo));
+  return repos.filter(repo => !excludedRepos.has(normalizeRepo(repo)));
+}
+
+export async function getDefaultRepos(): Promise<string[]> {
+  const cacheKey = `default-repos:${JSON.stringify({
+    orgs: config.orgs,
+    include: config.repos.include,
+    exclude: config.repos.exclude,
+  })}`;
+
+  return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
+    if (config.repos.include.length > 0) {
+      return config.repos.include;
+    }
+
+    const discoveredRepos = filterExcludedRepos(await getAllRepositoriesFromOrgs(config.orgs));
+    return discoveredRepos.length > 0 ? discoveredRepos : FALLBACK_REPOS;
+  });
+}

--- a/lib/employees.ts
+++ b/lib/employees.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { config } from './config';
 import { cache } from './cache';
-import { RateLimitError, getOrgMembersGraphQL, getOrgMembersREST, getRepoCollaboratorsREST } from './github';
+import { RateLimitError, getExcludedLogins, getOrgMembersGraphQL, getOrgMembersREST, getRepoCollaboratorsREST } from './github';
 import { EmployeeOverrides, LoginOverrides, MaintainerOverrides, RepoAuthorRoleSets } from './types';
 import { isBotLogin } from './bots';
 
@@ -37,40 +37,59 @@ function loadMaintainerOverrides(): MaintainerOverrides {
   return loadOverrides('maintainers.json');
 }
 
+function normalizeLogin(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+async function getFallbackOrgMembers(): Promise<string[]> {
+  const members = new Set<string>();
+
+  for (const org of config.orgs) {
+    try {
+      let orgMembers: string[];
+      try {
+        orgMembers = await getOrgMembersGraphQL(org);
+      } catch (error) {
+        console.warn(`GraphQL failed for org ${org}, falling back to REST:`, error);
+        orgMembers = await getOrgMembersREST(org);
+      }
+
+      orgMembers.forEach(member => members.add(normalizeLogin(member)));
+    } catch (error) {
+      console.error(`Failed to fetch members for org ${org}:`, error);
+    }
+  }
+
+  return Array.from(members);
+}
+
+async function getEmployeeSourceLogins(): Promise<string[]> {
+  try {
+    const excludedLogins = await getExcludedLogins();
+    const employeeLogins = excludedLogins
+      .filter(entry => entry.reason.toLowerCase() === 'employee or org member')
+      .map(entry => normalizeLogin(entry.login));
+
+    if (employeeLogins.length > 0) {
+      return employeeLogins;
+    }
+  } catch (error) {
+    console.warn('Failed to fetch excluded login source, falling back to org membership:', error);
+  }
+
+  return getFallbackOrgMembers();
+}
+
 export async function buildEmployeesSet(): Promise<Set<string>> {
   const cacheKey = `employees:${config.orgs.join(',')}`;
-  
+
   return cache.withCache(cacheKey, config.cache.ttlSeconds, async () => {
-    const employees = new Set<string>();
-    
-    // Fetch org members for each organization
-    for (const org of config.orgs) {
-      try {
-        // Try GraphQL first, fallback to REST
-        let members: string[];
-        try {
-          members = await getOrgMembersGraphQL(org);
-        } catch (error) {
-          console.warn(`GraphQL failed for org ${org}, falling back to REST:`, error);
-          members = await getOrgMembersREST(org);
-        }
-        
-        members.forEach(member => employees.add(member));
-      } catch (error) {
-        console.error(`Failed to fetch members for org ${org}:`, error);
-        // Continue with other orgs
-      }
-    }
-    
-    // Apply overrides from config file
+    const employees = new Set<string>(await getEmployeeSourceLogins());
     const overrides = loadEmployeeOverrides();
-    
-    // Add allowlist members
-    overrides.allowlist.forEach(login => employees.add(login));
-    
-    // Remove denylist members
-    overrides.denylist.forEach(login => employees.delete(login));
-    
+
+    overrides.allowlist.forEach(login => employees.add(normalizeLogin(login)));
+    overrides.denylist.forEach(login => employees.delete(normalizeLogin(login)));
+
     return employees;
   });
 }
@@ -111,7 +130,7 @@ export async function buildRepoAuthorRoleSets(owner: string, repo: string): Prom
 }
 
 export function isEmployee(login: string, employeesSet: Set<string>): boolean {
-  return employeesSet.has(login);
+  return employeesSet.has(normalizeLogin(login));
 }
 
 export type AuthorType = 'employee' | 'maintainer' | 'collaborator' | 'community' | 'bot';

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -303,6 +303,31 @@ export async function getAllRepositoriesFromOrgs(orgs: string[]): Promise<string
   return allRepos;
 }
 
+export type ExcludedLoginEntry = {
+  login: string;
+  reason: string;
+};
+
+export async function getExcludedLogins(): Promise<ExcludedLoginEntry[]> {
+  const response = await fetchGitHub(
+    'https://raw.githubusercontent.com/OpenHands/champions-list/main/data/excluded-logins.json'
+  );
+
+  const data = await response.json() as {
+    logins?: Array<{ login?: string; reason?: string }>;
+  };
+
+  return (data.logins ?? [])
+    .filter((entry): entry is { login: string; reason: string } =>
+      typeof entry?.login === 'string' && typeof entry?.reason === 'string'
+    )
+    .map(entry => ({
+      login: entry.login,
+      reason: entry.reason,
+    }));
+}
+
+
 export type CompletedReviewData = {
   reviewerLogin: string;
   authorAssociation: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -81,6 +81,8 @@ export type FilterState = {
   repositories: string[];
   labels: string[];
   ageRange: string;
+  startDate?: string;
+  endDate?: string;
   status?: string;
   noReviewers?: boolean;
   limit?: string;


### PR DESCRIPTION
## Summary
- discover the default repository scope dynamically so the dashboard and repository selector use all public repos in the configured `OpenHands` org by default
- narrow the default dashboard view to non-draft PRs that need review and became ready in the last 7 days, with explicit ready-from / ready-to filters
- source employee classification from `OpenHands/champions-list` excluded logins, remove `raymyers` from maintainers, and recognize explicit bot accounts including `smolpaws`

## Testing
- `npm test -- --runInBand`
- `npm run build`
- `npm run lint` _(warnings only; no new lint errors)_

Closes #34

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/486e5bb3-fe42-40b4-a790-3e2a3d0e98c0)